### PR TITLE
Add function to reload WS creds from configs

### DIFF
--- a/src/MicroOcppMongooseClient.h
+++ b/src/MicroOcppMongooseClient.h
@@ -61,8 +61,7 @@ private:
     bool connection_closing {false};
     ReceiveTXTcallback receiveTXTcallback = [] (const char *, size_t) {return false;};
 
-    bool credentials_changed {true}; //set credentials to be reloaded
-    void reload_credentials();
+    void reconnect();
 
     void maintainWsConn();
 
@@ -88,12 +87,13 @@ public:
         return receiveTXTcallback;
     }
 
+    //update WS configs. To apply the updates, call `reloadConfigs()` afterwards
     void setBackendUrl(const char *backend_url);
     void setChargeBoxId(const char *cb_id);
     void setAuthKey(const char *auth_key);
     void setCaCert(const char *ca_cert); //forwards this string to Mongoose as ssl_ca_cert (see https://github.com/cesanta/mongoose/blob/ab650ec5c99ceb52bb9dc59e8e8ec92a2724932b/mongoose.h#L4192)
 
-    void reconnect(); //after updating all credentials, reconnect to apply them
+    void reloadConfigs();
 
     const char *getBackendUrl() {return backend_url.c_str();}
     const char *getChargeBoxId() {return cb_id.c_str();}

--- a/src/MicroOcppMongooseClient_c.cpp
+++ b/src/MicroOcppMongooseClient_c.cpp
@@ -74,13 +74,13 @@ void ocpp_setCaCert(OCPP_Connection *sock, const char *ca_cert) {
     mgsock->setCaCert(ca_cert);
 }
 
-void ocpp_reconnect(OCPP_Connection *sock) {
+void ocpp_reloadConfigs(OCPP_Connection *sock) {
     if (!sock) {
         MOCPP_DBG_ERR("invalid argument");
         return;
     }
     auto mgsock = reinterpret_cast<MOcppMongooseClient*>(sock);
-    mgsock->reconnect();
+    mgsock->reloadConfigs();
 }
 
 const char *ocpp_getBackendUrl(OCPP_Connection *sock) {

--- a/src/MicroOcppMongooseClient_c.h
+++ b/src/MicroOcppMongooseClient_c.h
@@ -29,12 +29,13 @@ OCPP_Connection *ocpp_makeConnection(struct mg_mgr *mgr,
 
 void ocpp_deinitConnection(OCPP_Connection *sock);
 
+//update WS configs. To apply the updates, call `ocpp_reloadConfigs()` afterwards
 void ocpp_setBackendUrl(OCPP_Connection *sock, const char *backend_url);
 void ocpp_setChargeBoxId(OCPP_Connection *sock, const char *cb_id);
 void ocpp_setAuthKey(OCPP_Connection *sock, const char *auth_key);
 void ocpp_setCaCert(OCPP_Connection *sock, const char *ca_cert);
 
-void ocpp_reconnect(OCPP_Connection *sock); //after updating all credentials, reconnect to apply them
+void ocpp_reloadConfigs(OCPP_Connection *sock);
 
 const char *ocpp_getBackendUrl(OCPP_Connection *sock);
 const char *ocpp_getChargeBoxId(OCPP_Connection *sock);


### PR DESCRIPTION
The Mongoose WS adapter needs to react differently when the OCPP server updates the WS credentials (e.g. "Cst_BackendUrl") vs. the client code locally updates the WS credentials. This PR changes the API to reduce the complexity of the differentiation:

- `void setBackendUrl(const char*)`, `void setChargeBoxId(const char*)` and `void setAuthKey(const char*)` don't take immediate effect anymore. The credentials updates need to be applied manually using `void reloadConfigs()`
- the client code can also update the WS credentials by programmatically updating the underlying OCPP configs and apply the updates using `void reloadConfigs()`
- `void reconnect()` is not part of the configs update procedure anymore and was changed to private