### PR TITLE
FTPS (FTP over TLS) support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ target_include_directories(MicroOcppMongoose PUBLIC
                             )
 
 target_compile_definitions(MicroOcppMongoose PRIVATE
-    )
+    MG_ENABLE_OPENSSL=1
+)
 
 target_link_libraries(MicroOcppMongoose PUBLIC MicroOcpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(MicroOcppMongoose PUBLIC
                             )
 
 target_compile_definitions(MicroOcppMongoose PRIVATE
-    MG_ENABLE_OPENSSL=1
+    MG_ENABLE_MBEDTLS=1
 )
 
 target_link_libraries(MicroOcppMongoose PUBLIC MicroOcpp)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,50 @@ The setup is done if the following include statements work:
 
 The last dependency is [base64-converter by Densaugeo](https://github.com/Densaugeo/base64_arduino), but it is already included in this repository. Thanks to [Densaugeo](https://github.com/Densaugeo) for providing it!
 
+## Additional FTP(s) Client
+
+This library also contains an experimental FTP client based on Mongoose. Its intended use is to download firmware binaries and to upload hardware diagnostics information as part of the OCPP UpdateFirmware / GetDiagnostics operations.
+
+Currently, the compatibility with the following FTP servers has been tested:
+
+| Server | FTP | FTPS |
+| --- | --- | --- |
+| [vsftp](https://security.appspot.com/vsftpd.html) | ✔️ | ✔️ |
+| [Pure-FTPd](https://www.pureftpd.org/project/pure-ftpd/) | ✔️ | |
+
+The following code snippet shows how to use the FTP client:
+
+```cpp
+struct mg_mgr mgr;
+//initialize mgr
+
+MicroOcpp::MongooseFtpClient ftp {&mgr};
+
+if (/* test FTP download */) {
+    ftp.getFile("ftps://ftpuser:secret123@ftp.example.com/dir/firmware.bin",
+            [] (unsigned char *data, size_t len) -> size_t {
+                //write firmware data on flash
+                return len;
+            }, [] () {
+                //finalize OTA update
+            });
+
+} else if (/* test FTP upload */) {
+    ftp.postFile("ftps://ftpuser:secret123@ftp.example.com/dir/diagnostics.log",
+            [] (unsigned char *data, size_t len) -> size_t {
+                //write diagnostics text to `data` having length `len`
+                return /* written */; //return number of bytes actually written to data (if 0, upload will be finished)
+            }, [] () {
+                //connection close callback
+            });
+}
+
+for (;;) {
+    mg_mgr_poll(&mgr, 100);
+    ftp.loop(); //only necessary for Mongoose v6
+}
+```
+
 ## License
 
 This project is licensed under the GPL as it uses the [Mongoose Embedded Networking Library](https://github.com/cesanta/mongoose). If you have a proprietary license of Mongoose, then the [MIT License](https://github.com/matth-x/MicroOcpp/blob/master/LICENSE) applies.

--- a/src/MicroOcppMongooseFtp.cpp
+++ b/src/MicroOcppMongooseFtp.cpp
@@ -456,7 +456,10 @@ void ftp_data_cb(struct mg_connection *c, int ev, void *ev_data, void *fn_data) 
             struct mg_tls_opts opts;
             memset(&opts, 0, sizeof(opts));
             //opts.ca = CERT; //TODO
+            int save_is_connecting = c->is_connecting;
+            c->is_connecting = 1; //do not perform tls_handshake during mg_tls_init
             mg_tls_init(c, &opts);
+            c->is_connecting = save_is_connecting;
             #endif
 
             //reuse session of control conn for data conn

--- a/src/MicroOcppMongooseFtp.h
+++ b/src/MicroOcppMongooseFtp.h
@@ -52,14 +52,13 @@ public:
 
     bool data_conn_accepted = false;
 
-#if MO_MG_VERSION_614
-    //upgrade TLS in FtpClient::loop instead of mg_poll (MG flags cannot be manipulated in mg_poll)
+    //upgrade TLS in FtpClient::loop and not in cb fn (MG flags cannot be manipulated during mg_poll in MG v6.14)
     bool ctrl_tls_want_upgrade = false;
     bool data_tls_want_upgrade = false;
-#endif
+
     int upgradeTls(struct mg_connection *conn);
-    int reuseTlsSession(); //reuse ctrl_conn session for data_conn (after ssl-lib init and before ssl-lib handshake)
-    int data_tls_reuse_session(); //reuse ctrl_conn session for data_conn (after ssl-lib init and before ssl-lib handshake)
+    int upgradeTlsCtrlConn();
+    int upgradeTlsDataConn();
 
     MongooseFtpClient(struct mg_mgr *mgr);
     ~MongooseFtpClient();

--- a/src/MicroOcppMongooseFtp.h
+++ b/src/MicroOcppMongooseFtp.h
@@ -54,8 +54,12 @@ public:
 
 #if MO_MG_VERSION_614
     //upgrade TLS in FtpClient::loop instead of mg_poll (MG flags cannot be manipulated in mg_poll)
-    bool tls_want_upgrade = false;
+    bool ctrl_tls_want_upgrade = false;
+    bool data_tls_want_upgrade = false;
 #endif
+    int upgradeTls(struct mg_connection *conn);
+    int reuseTlsSession(); //reuse ctrl_conn session for data_conn (after ssl-lib init and before ssl-lib handshake)
+    int data_tls_reuse_session(); //reuse ctrl_conn session for data_conn (after ssl-lib init and before ssl-lib handshake)
 
     MongooseFtpClient(struct mg_mgr *mgr);
     ~MongooseFtpClient();

--- a/src/MicroOcppMongooseFtp.h
+++ b/src/MicroOcppMongooseFtp.h
@@ -52,8 +52,15 @@ public:
 
     bool data_conn_accepted = false;
 
+#if MO_MG_VERSION_614
+    //upgrade TLS in FtpClient::loop instead of mg_poll (MG flags cannot be manipulated in mg_poll)
+    bool tls_want_upgrade = false;
+#endif
+
     MongooseFtpClient(struct mg_mgr *mgr);
     ~MongooseFtpClient();
+
+    void loop(); //need to loop during TLS negotiation when using Mongoose v6.14
 
     bool getFile(const char *ftp_url, // ftp[s]://[user[:pass]@]host[:port][/directory]/filename
             std::function<size_t(unsigned char *data, size_t len)> fileWriter,

--- a/src/MicroOcppMongooseFtp.h
+++ b/src/MicroOcppMongooseFtp.h
@@ -24,6 +24,7 @@ public:
     struct mg_connection *ctrl_conn {nullptr};
     struct mg_connection *data_conn {nullptr};
     std::string file_location;
+    std::string proto;
     std::string url;
     std::string user;
     std::string pass;
@@ -54,12 +55,12 @@ public:
     MongooseFtpClient(struct mg_mgr *mgr);
     ~MongooseFtpClient();
 
-    bool getFile(const char *ftp_url, // ftp://[user[:pass]@]host[:port][/directory]/filename
+    bool getFile(const char *ftp_url, // ftp[s]://[user[:pass]@]host[:port][/directory]/filename
             std::function<size_t(unsigned char *data, size_t len)> fileWriter,
             std::function<void()> onClose);
     
     //append file
-    bool postFile(const char *ftp_url, // ftp://[user[:pass]@]host[:port][/directory]/filename
+    bool postFile(const char *ftp_url, // ftp[s]://[user[:pass]@]host[:port][/directory]/filename
             std::function<size_t(unsigned char *out, size_t buffsize)> fileReader, //write at most buffsize bytes into out-buffer. Return number of bytes written
             std::function<void()> onClose);
 };


### PR DESCRIPTION
Experimental support of [RFC 4217](https://datatracker.ietf.org/doc/html/rfc4217) (Securing FTP with TLS).

Compatibility was tested with vsftpd and its default configuration (highest protection level).

The overall FTP client is still in an experimental stage. Feel free to evaluate it and report any issues or further compatible servers.