### PR TITLE
OCPP 2.0.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - ~FTP over TLS support ([#3](https://github.com/matth-x/MicroOcppMongoose/pull/3))~ (see [#5](https://github.com/matth-x/MicroOcppMongoose/pull/5))
+- OCPP 2.0.1 compatibility ([#6](https://github.com/matth-x/MicroOcppMongoose/pull/6))
 
 ### Removed
 

--- a/src/MicroOcppMongooseClient.cpp
+++ b/src/MicroOcppMongooseClient.cpp
@@ -23,7 +23,8 @@ MOcppMongooseClient::MOcppMongooseClient(struct mg_mgr *mgr,
             const char *charge_box_id_factory,
             const char *auth_key_factory,
             const char *CA_cert_factory,
-            std::shared_ptr<FilesystemAdapter> filesystem) : mgr(mgr) {
+            std::shared_ptr<FilesystemAdapter> filesystem,
+            ProtocolVersion protocolVersion) : mgr(mgr), protocolVersion(protocolVersion) {
     
     bool readonly;
     
@@ -209,7 +210,8 @@ void MOcppMongooseClient::maintainWsConn() {
         url.c_str(), 
         ws_cb, 
         this, 
-        "%s%s%s\r\n", "Sec-WebSocket-Protocol: ocpp1.6",
+        "Sec-WebSocket-Protocol: %s%s%s\r\n",
+                      protocolVersion.major == 2 ? "ocpp2.0.1" : "ocpp1.6",
                       basic_auth64.empty() ? "" : "\r\nAuthorization: Basic ", 
                       basic_auth64.empty() ? "" : basic_auth64.c_str());     // Create client
 #endif

--- a/src/MicroOcppMongooseClient.cpp
+++ b/src/MicroOcppMongooseClient.cpp
@@ -1,5 +1,5 @@
 // matth-x/MicroOcppMongoose
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // GPL-3.0 License (see LICENSE)
 
 #include "MicroOcppMongooseClient.h"
@@ -196,7 +196,7 @@ void MOcppMongooseClient::maintainWsConn() {
         this,
         opts,
         url.c_str(),
-        "ocpp1.6",
+        protocolVersion.major == 2 ? "ocpp2.0.1" : "ocpp1.6",
         *extra_headers ? extra_headers : nullptr);
 
     if (websocket) {

--- a/src/MicroOcppMongooseClient.h
+++ b/src/MicroOcppMongooseClient.h
@@ -12,6 +12,7 @@
 
 #include "mongoose.h"
 #include <MicroOcpp/Core/Connection.h>
+#include <MicroOcpp/Version.h>
 
 #include <string>
 #include <memory>
@@ -61,6 +62,8 @@ private:
     bool connection_closing {false};
     ReceiveTXTcallback receiveTXTcallback = [] (const char *, size_t) {return false;};
 
+    ProtocolVersion protocolVersion;
+
     void reconnect();
 
     void maintainWsConn();
@@ -71,7 +74,8 @@ public:
             const char *charge_box_id_factory = nullptr,
             const char *auth_key_factory = nullptr,
             const char *CA_cert_factory = nullptr, //forwards this string to Mongoose as ssl_ca_cert (see https://github.com/cesanta/mongoose/blob/ab650ec5c99ceb52bb9dc59e8e8ec92a2724932b/mongoose.h#L4192)
-            std::shared_ptr<MicroOcpp::FilesystemAdapter> filesystem = nullptr);
+            std::shared_ptr<MicroOcpp::FilesystemAdapter> filesystem = nullptr,
+            ProtocolVersion protocolVersion = ProtocolVersion(1,6));
 
     ~MOcppMongooseClient();
 


### PR DESCRIPTION
For OCPP 2.0.1, the WebSocket client needs to specify a different protocol version during WS negotiation. Add a new ProtocolVersion parameter and send the selected version correspondingly.