### PR TITLE
Set server domain name for TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - ~FTP over TLS support ([#3](https://github.com/matth-x/MicroOcppMongoose/pull/3))~ (see [#5](https://github.com/matth-x/MicroOcppMongoose/pull/5))
 - OCPP 2.0.1 compatibility ([#6](https://github.com/matth-x/MicroOcppMongoose/pull/6))
-- Send host name in TLS handshake
+- Send host name in TLS handshake ([#9](https://github.com/matth-x/MicroOcppMongoose/pull/9))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - ~FTP over TLS support ([#3](https://github.com/matth-x/MicroOcppMongoose/pull/3))~ (see [#5](https://github.com/matth-x/MicroOcppMongoose/pull/5))
 - OCPP 2.0.1 compatibility ([#6](https://github.com/matth-x/MicroOcppMongoose/pull/6))
+- Send host name in TLS handshake
 
 ### Removed
 

--- a/src/MicroOcppMongooseClient.cpp
+++ b/src/MicroOcppMongooseClient.cpp
@@ -468,7 +468,10 @@ void ws_cb(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
                 //yes, disabled
                 ca_string = nullptr;
             }
-            struct mg_tls_opts opts = {.ca = ca_string};
+            struct mg_tls_opts opts;
+            memset(&opts, 0, sizeof(struct mg_tls_opts));
+            opts.ca = ca_string;
+            opts.srvname = mg_url_host(osock->getUrl());
             mg_tls_init(c, &opts);
         } else {
             MO_DBG_WARN("Insecure connection (WS)");


### PR DESCRIPTION
This change allows MbedTLS to check the domain name against the provided certificate and to send the name to the server during the TLS handshake for SNI.