### PR TITLE
Add Mongoose v7.13 and v7.14 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Mongoose v7.13 support
+
 ## [v1.1.0] - 2024-05-21
 
 ### Changed

--- a/src/MicroOcppMongooseClient.cpp
+++ b/src/MicroOcppMongooseClient.cpp
@@ -16,9 +16,9 @@
 
 #ifndef MO_MG_USE_VERSION
 #if defined(MO_MG_VERSION_614)
-#define MO_MG_USE_VERSION=MO_MG_V614
+#define MO_MG_USE_VERSION MO_MG_V614
 #else
-#define MO_MG_V708
+#define MO_MG_USE_VERSION MO_MG_V708
 #endif
 #endif
 


### PR DESCRIPTION
This PR adds support for the 2 latest Mongoose minor versions and changes how to select the MG version.

The available MG versions are defined here:

https://github.com/matth-x/MicroOcppMongoose/blob/dae388fe04beff6174b7fc30bc67dd4ad8343df3/src/MicroOcppMongooseClient.cpp#L12-L15

To choose which MG should be used, set the build flag `MO_MG_USE_VERSION`, e.g.

```cpp
MO_MG_USE_VERSION=MO_MG_V714
```
