### PR TITLE
fix converting authorization key to hex string

### DIFF
--- a/src/MicroOcppMongooseClient.cpp
+++ b/src/MicroOcppMongooseClient.cpp
@@ -54,7 +54,7 @@ MOcppMongooseClient::MOcppMongooseClient(struct mg_mgr *mgr,
     char auth_key_hex [2 * MO_AUTHKEY_LEN_MAX + 1];
     auth_key_hex[0] = '\0';
     if (auth_key_factory) {
-        for (size_t i = 0; i < auth_key_factory_len; i += 2) {
+        for (size_t i = 0; i < auth_key_factory_len; i++) {
             snprintf(auth_key_hex + 2 * i, 3, "%02X", auth_key_factory[i]);
         }
     }
@@ -357,7 +357,7 @@ void MOcppMongooseClient::setAuthKey(const unsigned char *auth_key, size_t len) 
 
     char auth_key_hex [2 * MO_AUTHKEY_LEN_MAX + 1];
     auth_key_hex[0] = '\0';
-    for (size_t i = 0; i < len; i += 2) {
+    for (size_t i = 0; i < len; i++) {
         snprintf(auth_key_hex + 2 * i, 3, "%02X", auth_key[i]);
     }
 


### PR DESCRIPTION
Hi,

In the AuthKey raw-to-hex conversion loop, the loop variable was incremented by 2 (`i += 2`) which skipped every second byte in `auth_key_factory`. In addition, the `snprintf(auth_key_hex + 2 * i, ...)` wrote to index 4 in the second loop execution, while the first loop execution wrote a `\0` to index 2, thus the variable `auth_key_hex` always contained only 2 characters (plus zero-termination). So in the end, only the first byte of `auth_key_factory` was stored, the rest was completely lost.

I found this because the authentication didn't work for me. Changing `i += 2` to `i++` fixed the problem. The same problem existed in `setAuthKey()`. Note that there was already a place where the conversion was correct:

https://github.com/matth-x/MicroOcppMongoose/blob/95f4748f0863ab276f2b5481d29a3281a38a0a36/src/MicroOcppMongooseClient.cpp#L202-L211

Just let me know if I need to adjust anything.