### PR TITLE
Add Variables for OCPP 2.0.1 URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Mongoose v7.13 - v7.15 support ([#11](https://github.com/matth-x/MicroOcppMongoose/pull/11), [#14](https://github.com/matth-x/MicroOcppMongoose/pull/14))
-- OCPP 2.0.1 BasicAuthPassword integration ([#13](https://github.com/matth-x/MicroOcppMongoose/pull/13))
+- OCPP 2.0.1 Variables integration ([#13](https://github.com/matth-x/MicroOcppMongoose/pull/13)), ([#16](https://github.com/matth-x/MicroOcppMongoose/pull/16))
 
 ### Fixed
 - AuthorizationKey hex conversion ([#12](https://github.com/matth-x/MicroOcppMongoose/pull/12), [#15](https://github.com/matth-x/MicroOcppMongoose/pull/15))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Mongoose v7.13 - v7.15 support ([#11](https://github.com/matth-x/MicroOcppMongoose/pull/11), [#14](https://github.com/matth-x/MicroOcppMongoose/pull/14))
-- OCPP 2.0.1 Variables integration ([#13](https://github.com/matth-x/MicroOcppMongoose/pull/13)), ([#16](https://github.com/matth-x/MicroOcppMongoose/pull/16))
+- OCPP 2.0.1 Variables integration ([#13](https://github.com/matth-x/MicroOcppMongoose/pull/13), [#16](https://github.com/matth-x/MicroOcppMongoose/pull/16))
 
 ### Fixed
 - AuthorizationKey hex conversion ([#12](https://github.com/matth-x/MicroOcppMongoose/pull/12), [#15](https://github.com/matth-x/MicroOcppMongoose/pull/15))

--- a/src/MicroOcppMongooseClient.h
+++ b/src/MicroOcppMongooseClient.h
@@ -60,7 +60,9 @@ private:
     unsigned long last_hb {0};
 #if MO_ENABLE_V201
     std::unique_ptr<VariableContainerOwning> websocketSettings;
-    Variable *basicAuthPasswordString = nullptr;
+    Variable *v201csmsUrlString = nullptr;
+    Variable *v201identityString = nullptr;
+    Variable *v201basicAuthPasswordString = nullptr;
 #endif
     bool connection_established {false};
     unsigned long last_connection_established {-1UL / 2UL};

--- a/src/MicroOcppMongooseClient.h
+++ b/src/MicroOcppMongooseClient.h
@@ -36,6 +36,7 @@ class Configuration;
 #if MO_ENABLE_V201
 class Variable;
 class VariableContainer;
+class VariableContainerOwning;
 #endif
 
 class MOcppMongooseClient : public MicroOcpp::Connection {
@@ -58,7 +59,7 @@ private:
     std::shared_ptr<Configuration> ws_ping_interval_int; //heartbeat intervall in s. 0 sets hb off
     unsigned long last_hb {0};
 #if MO_ENABLE_V201
-    std::shared_ptr<VariableContainer> websocketSettings;
+    std::unique_ptr<VariableContainerOwning> websocketSettings;
     Variable *basicAuthPasswordString = nullptr;
 #endif
     bool connection_established {false};
@@ -133,7 +134,7 @@ public:
 #if MO_ENABLE_V201
     //WS client creates and manages its own Variables. This getter function is a temporary solution, in future
     //the WS client will be initialized with a Context reference for registering the Variables directly
-    std::shared_ptr<VariableContainer> getVariableContainer();
+    VariableContainer *getVariableContainer();
 #endif
 };
 


### PR DESCRIPTION
This PR adds the Variables CsmsUrl and Identity to the SecurityCtrlr component

Now, the WS client supports:
- CsmsUrl (**new**): backend URL, relating to the ocppCsmsUrl of a NetworkProfile
- Identity (**new**): the v2.0.1 pendant to ChargeBoxId
- BasicAuthPassword (already existing): WS password

CsmsUrl is a custom Variable and not specified by OCPP 2.0.1 which describes the NetworkProfile mechanism for configuring the backend URL. MicroOCPP does not support the NetworkProfile mechanism yet, so this approach of handling the backend URL in a Variable is only an intermediate solution.