### PR TITLE
Add MG v717 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Mongoose v7.17 support ([#18](https://github.com/matth-x/MicroOcppMongoose/pull/18))
+
 ## [v1.2.0] - 2024-11-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mongoose WebSocket adapter for MicroOCPP
 
 The following projects must be available on the include path:
 
-- [Mongoose Embedded Networking Library v6.14 / v7.8 / v7.13 - v7.15](https://github.com/cesanta/mongoose/tree/76e6b23a4f0261dd534d33632f42ea1bba99dc85): The MicroOcppMongoose adapter works with the amalgamated files `mongoose.h` and `mongoose.c`. You may need to copy them from the Mongoose-repository into the `src` folder of your project. To configure the Mongoose version in MicroOcppMongoose, set the build flag `MO_MG_USE_VERSION`, e.g. `MO_MG_USE_VERSION=MO_MG_V715`.
+- [Mongoose Embedded Networking Library v6.14 / v7.8 / v7.13 - v7.17](https://github.com/cesanta/mongoose/tree/7.17/): The MicroOcppMongoose adapter works with the amalgamated files `mongoose.h` and `mongoose.c`. You may need to copy them from the Mongoose-repository into the `src` folder of your project. To configure the Mongoose version in MicroOcppMongoose, set the build flag `MO_MG_USE_VERSION`, e.g. `MO_MG_USE_VERSION=MO_MG_V717`.
 - [ArduinoJson v6](https://github.com/bblanchon/ArduinoJson/tree/079ccadbee4100ad0b2d06f11de8c412b95853c1) (no support for v7 yet)
 - [MicroOCPP](https://github.com/matth-x/MicroOcpp)
 

--- a/src/MicroOcppMongooseClient.cpp
+++ b/src/MicroOcppMongooseClient.cpp
@@ -18,6 +18,7 @@
 #define MO_MG_V713 713
 #define MO_MG_V714 714
 #define MO_MG_V715 715
+#define MO_MG_V717 717
 
 #ifndef MO_MG_USE_VERSION
 #if defined(MO_MG_VERSION_614)
@@ -142,6 +143,12 @@ MOcppMongooseClient::MOcppMongooseClient(struct mg_mgr *mgr,
     MO_DBG_DEBUG("use MG version %s (tested with 7.8)", MG_VERSION);
 #elif MO_MG_USE_VERSION == MO_MG_V713
     MO_DBG_DEBUG("use MG version %s (tested with 7.13)", MG_VERSION);
+#elif MO_MG_USE_VERSION == MO_MG_V714
+    MO_DBG_DEBUG("use MG version %s (tested with 7.14)", MG_VERSION);
+#elif MO_MG_USE_VERSION == MO_MG_V715
+    MO_DBG_DEBUG("use MG version %s (tested with 7.15)", MG_VERSION);
+#elif MO_MG_USE_VERSION == MO_MG_V717
+    MO_DBG_DEBUG("use MG version %s (tested with 7.17)", MG_VERSION);
 #endif
 
     maintainWsConn();


### PR DESCRIPTION
Tested the previous v715 integration with v717 and everything works without changes. Adding v717 to the officially supported Mongoose versions.

See #11 on how to select the MG version.